### PR TITLE
Surround autocmd with augroup

### DIFF
--- a/plugin/gen_ctags.vim
+++ b/plugin/gen_ctags.vim
@@ -221,7 +221,10 @@ function! UpdateCtags()
 
   call s:Ctags_db_gen("", "")
 endfunction
-au BufWritePost * call UpdateCtags()
+augroup gen_ctags
+    au!
+    au BufWritePost * call UpdateCtags()
+augroup END
 
 "Add db while startup
 call s:Add_DBs()

--- a/plugin/gen_gtags.vim
+++ b/plugin/gen_gtags.vim
@@ -129,7 +129,10 @@ function! UpdateGtags()
 
   echon " " | echohl Function | echon "[Background]" | echohl None
 endfunction
-au BufWritePost * call UpdateGtags()
+augroup gen_gtags
+    au!
+    au BufWritePost * call UpdateGtags()
+augroup END
 
 "Add db while startup
 call s:Add_DBs()


### PR DESCRIPTION
Fix bug that re-register the autocmd when resourcing `.vimrc` without restart vim.
