### PR TITLE
Don't display "not found" messages for disabled ctags/Global.

### DIFF
--- a/plugin/gen_tags.vim
+++ b/plugin/gen_tags.vim
@@ -8,24 +8,24 @@ if !exists('g:gen_tags#ctags_bin')
   let g:gen_tags#ctags_bin = 'ctags'
 endif
 
-if executable(g:gen_tags#ctags_bin)
-  if !get(g:, 'loaded_gentags#ctags', 0)
+if !get(g:, 'loaded_gentags#ctags', 0)
+  if executable(g:gen_tags#ctags_bin)
     call gen_tags#ctags#init()
+  else
+    echomsg 'ctags not found'
+    echomsg 'gen_tags.vim need ctags to generate tags'
   endif
-else
-  echomsg 'ctags not found'
-  echomsg 'gen_tags.vim need ctags to generate tags'
 endif
 
 "Initial gtags support
-if has('cscope') && executable('gtags')
-  if !get(g:, 'loaded_gentags#gtags', 0)
+if !get(g:, 'loaded_gentags#gtags', 0)
+  if has('cscope') && executable('gtags')
     call gen_tags#gtags#init()
+  elseif !has('cscope')
+    echomsg 'Need cscope support'
+    echomsg 'gen_gtags.vim need cscope support'
+  elseif !executable('gtags') && !executable('gtags.exe')
+    echomsg 'GNU Global not found'
+    echomsg 'gen_gtags.vim need GNU Global'
   endif
-elseif !has('cscope')
-  echomsg 'Need cscope support'
-  echomsg 'gen_gtags.vim need cscope support'
-elseif !executable('gtags') && !executable('gtags.exe')
-  echomsg 'GNU Global not found'
-  echomsg 'gen_gtags.vim need GNU Global'
 endif


### PR DESCRIPTION
Commit d7cd31b763adaa8df031caefa71ff3b46a195587 made gen_tags echo `{ctags/GNU Global} not found` messages on every vim startup if both executables weren't installed, even with `loaded_gentags#{ctags,gtags}` set to disable one of the tools.

I reordered the `if`s to make the `loaded...` variables respected again.