### PR TITLE
Make gtags complement available for many languages

### DIFF
--- a/rplugin/python3/deoplete/sources/gtags.py
+++ b/rplugin/python3/deoplete/sources/gtags.py
@@ -13,7 +13,6 @@ class Source(Base):
 
         self.name = 'gtags'
         self.mark = '[gtags]'
-        self.filetypes = ['c', 'cpp', 'java', 'php']
         self.input_pattern = (r'\w+')
         self.rank = 100
 


### PR DESCRIPTION
GNU Global has a pygments plugin built in so that it can be used in so many languages.
https://github.com/yoshizow/global-pygments-plugin

I actually use deoplete gtags completion in Ruby and JavaScript languages.
deoplete automatically loads source when completion source is provided and attempts to use even if the name conflicts.
I am using [deoplete-gtags](https://github.com/ozelentok/deoplete-gtags) to complement gtags, but since this name conflicts with it, I can not use this plugin.
Can you delete the filetype specification so that gtags completion can be used in more languages?