### PR TITLE
Fix "E691: Can only compare List with List"

### DIFF
--- a/autoload/gen_tags/gtags.vim
+++ b/autoload/gen_tags/gtags.vim
@@ -42,7 +42,7 @@ function! s:gtags_db_gen() abort
     return
   endif
 
-  let l:cmd = 'gtags ' . l:db_dir
+  let l:cmd = ['gtags', l:db_dir]
 
   function! s:gtags_db_gen_done(...) abort
     call s:gtags_add(b:file)


### PR DESCRIPTION
I get follow output when :GenCtags :GenGTAGS.
> Error detected while processing function <SNR>21_gtags_db_gen[27]..gen_tags#sy
> stem_async[7]..<SNR>22_job_prune:
> line    2:
> E691: Can only compare List with List
> E15: Invalid expression: a:cmd ==# l:item['cmd']

I tried to fix it.