### PR TITLE
Like to like comparisons

### DIFF
--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -72,7 +72,15 @@ endfunction
 "Prune exit job from job list
 function! s:job_prune(cmd) abort
   for l:item in s:job_list
-    if a:cmd ==# l:item['cmd']
+    let l:cmd = a:cmd
+    let l:item_cmd = l:item['cmd']
+    if type(l:cmd) == type([])
+      let l:cmd = string(l:cmd)
+    endif
+    if type(l:item_cmd) == type([])
+      let l:item_cmd = string(l:item_cmd)
+    endif
+    if l:cmd ==# l:item_cmd
       let l:index = index(s:job_list, l:item)
       let l:job = l:item
     endif

--- a/autoload/gen_tags/gtags.vim
+++ b/autoload/gen_tags/gtags.vim
@@ -45,6 +45,9 @@ function! s:gtags_db_gen() abort
   let l:cmd = ['gtags', l:db_dir]
 
   function! s:gtags_db_gen_done(...) abort
+    if !exists('b:file')
+      return
+    endif
     call s:gtags_add(b:file)
     unlet b:file
   endfunction


### PR DESCRIPTION
I see two exceptions commonly using neovim (v0.2.3-776-g3d2f4154b).
 * Sometimes command is an array, sometimes it is a string. Automatically convert everything to strings before comparisons.
 * Occasionally b:file doesn't exist (probably a race condition); don't call gtags_add() when it doesn't exist.