### PR TITLE
Introduce g:gen_gtags#gtags_bin and g:gen_gtags#gtags_opts

### DIFF
--- a/autoload/gen_tags/gtags.vim
+++ b/autoload/gen_tags/gtags.vim
@@ -42,7 +42,7 @@ function! s:gtags_db_gen() abort
     return
   endif
 
-  let l:cmd = ['gtags', l:db_dir]
+  let l:cmd = [g:gen_tags#gtags_bin, l:db_dir, g:gen_tags#gtags_opts]
 
   function! s:gtags_db_gen_done(...) abort
     if !exists('b:file')
@@ -87,7 +87,7 @@ function! s:gtags_update() abort
 
   call gen_tags#echo('Update GTAGS in background')
 
-  let l:cmd = ['global', '-u']
+  let l:cmd = [g:gen_tags#global_bin, '-u']
   call gen_tags#system_async(l:cmd)
 endfunction
 
@@ -126,6 +126,10 @@ function! gen_tags#gtags#init() abort
 
   if !exists('g:gen_tags#gtags_auto_gen')
     let g:gen_tags#gtags_auto_gen = 0
+  endif
+
+  if !exists('g:gen_tags#gtags_opts')
+    let g:gen_tags#gtags_opts = ''
   endif
 
   call s:gtags_set_env()

--- a/doc/gen_tags.txt
+++ b/doc/gen_tags.txt
@@ -130,10 +130,27 @@ g:gen_tags#ctags_bin                            *g:gen_tags#ctags_bin*
 Set location of ctags. The default is 'ctags'
 
 ------------------------------------------------------------------------------
+g:gen_tags#gtags_bin                            *g:gen_tags#gtags_bin*
+
+Set location of ctags. The default is 'gtags'
+
+------------------------------------------------------------------------------
+g:gen_tags#global_bin                           *g:gen_tags#global_bin*
+
+Set location of global; a binary of gtags. The default is 'global'
+
+------------------------------------------------------------------------------
 g:gen_tags#ctags_opts                            *g:gen_tags#ctags_opts*
 
 Set ctags options. The `-R` is set by default,
 so there is no need to add `-R` in `g:gen_tags#ctags_opts`.
+The default `g:gen_tags#ctags_opts` is '', you need to set it in your vimrc
+
+------------------------------------------------------------------------------
+g:gen_tags#gtags_opts                            *g:gen_tags#gtags_opts*
+
+Set gtags options. The database path is the default.
+The gtags options will be before the database path.
 The default `g:gen_tags#ctags_opts` is '', you need to set it in your vimrc
 
 ------------------------------------------------------------------------------

--- a/plugin/gen_tags.vim
+++ b/plugin/gen_tags.vim
@@ -8,6 +8,14 @@ if !exists('g:gen_tags#ctags_bin')
   let g:gen_tags#ctags_bin = 'ctags'
 endif
 
+if !exists('g:gen_tags#gtags_bin')
+  let g:gen_tags#gtags_bin = 'gtags'
+endif
+
+if !exists('g:gen_tags#global_bin')
+  let g:gen_tags#global_bin = 'global'
+endif
+
 if !get(g:, 'loaded_gentags#ctags', 0)
   if executable(g:gen_tags#ctags_bin)
     call gen_tags#ctags#init()
@@ -19,12 +27,12 @@ endif
 
 "Initial gtags support
 if !get(g:, 'loaded_gentags#gtags', 0)
-  if has('cscope') && executable('gtags')
+  if has('cscope') && executable(g:gen_tags#gtags_bin)
     call gen_tags#gtags#init()
   elseif !has('cscope')
     echomsg 'Need cscope support'
     echomsg 'gen_gtags.vim need cscope support'
-  elseif !executable('gtags')
+  elseif !executable(g:gen_tags#gtags_bin)
     echomsg 'GNU Global not found'
     echomsg 'gen_gtags.vim need GNU Global'
   endif


### PR DESCRIPTION
g:gen_gtags#gtags_bin allows to use a different gtags binary file.

g:gen_gtags#gtags_opts allows to insert gtags options before the path to
database.