### PR TITLE
Display the tag generating message in statusline

### DIFF
--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -149,6 +149,8 @@ function! s:job_stdout(job_id, data, ...) abort
 endfunction
 
 function! s:job_start(cmd, ...) abort
+  call gen_tags#statusline#set('Generate tags in background, please stand by...')
+
   if has('nvim')
     let l:job = {
           \ 'on_stdout': function('s:job_stdout'),
@@ -182,6 +184,8 @@ function! s:job_start(cmd, ...) abort
     if a:0 != 0
       call a:1()
     endif
+
+    call gen_tags#statusline#clear()
 
     let l:job_id = -1
   endif

--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -149,7 +149,7 @@ function! s:job_stdout(job_id, data, ...) abort
 endfunction
 
 function! s:job_start(cmd, ...) abort
-  call gen_tags#statusline#set('Generate tags in background, please stand by...')
+  call gen_tags#statusline#set('Generating tags in background, please stand by...')
 
   if has('nvim')
     let l:job = {

--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -148,6 +148,10 @@ function! s:job_stdout(job_id, data, ...) abort
   endif
 endfunction
 
+function! s:job_exit(job_id, data, ...) abort
+  call gen_tags#statusline#clear()
+endfunction
+
 function! s:job_start(cmd, ...) abort
   call gen_tags#statusline#set('Generating tags in background, please stand by...')
 
@@ -155,6 +159,7 @@ function! s:job_start(cmd, ...) abort
     let l:job = {
           \ 'on_stdout': function('s:job_stdout'),
           \ 'on_stderr': function('s:job_stdout'),
+          \ 'on_exit': function('s:job_exit'),
           \ }
 
     if a:0 != 0
@@ -166,6 +171,7 @@ function! s:job_start(cmd, ...) abort
     let l:job = {
           \ 'out_cb': function('s:job_stdout'),
           \ 'err_cb': function('s:job_stdout'),
+          \ 'exit_cb': function('s:job_exit'),
           \ }
 
     if a:0 != 0

--- a/autoload/gen_tags/ctags.vim
+++ b/autoload/gen_tags/ctags.vim
@@ -70,7 +70,7 @@ function! s:ctags_gen(filename, dir) abort
   let l:dir = gen_tags#get_db_dir()
 
 
-  call gen_tags#echo('Generate project ctags database in backgroud')
+  call gen_tags#echo('Generate project ctags database in background')
 
   call gen_tags#mkdir(l:dir)
 
@@ -89,13 +89,19 @@ function! s:ctags_gen(filename, dir) abort
     let l:cmd += ['-f', l:file, '-R', g:gen_tags#ctags_opts, a:dir]
   endif
 
-  call gen_tags#system_async(l:cmd)
+  function! s:ctags_db_gen_done(...) abort
+    let l:dir = gen_tags#get_db_dir()
 
-  "Search for existence tags string.
-  let l:ret = stridx(&tags, l:dir)
-  if l:ret == -1
-    call s:ctags_add(l:file)
-  endif
+    "Search for existence tags string.
+    let l:ret = stridx(&tags, l:dir)
+    if l:ret == -1
+      call s:ctags_add(l:file)
+    endif
+
+    call gen_tags#statusline#clear()
+  endfunction
+
+  call gen_tags#system_async(l:cmd, function('s:ctags_db_gen_done'))
 endfunction
 
 function! s:ctags_auto_load() abort
@@ -144,6 +150,7 @@ function! s:ctags_clear(bang) abort
       let l:file = s:ctags_get_extend_name(l:item)
       if filereadable(l:file)
         call delete(l:file)
+        exec 'set tags-=' l:file
       endif
     endfor
   else

--- a/autoload/gen_tags/ctags.vim
+++ b/autoload/gen_tags/ctags.vim
@@ -89,11 +89,7 @@ function! s:ctags_gen(filename, dir) abort
     let l:cmd += ['-f', l:file, '-R', g:gen_tags#ctags_opts, a:dir]
   endif
 
-  function! s:ctags_db_gen_done(...) abort
-    call gen_tags#statusline#clear()
-  endfunction
-
-  call gen_tags#system_async(l:cmd, function('s:ctags_db_gen_done'))
+  call gen_tags#system_async(l:cmd)
 
   "Search for existence tags string.
   let l:ret = stridx(&tags, l:dir)

--- a/autoload/gen_tags/ctags.vim
+++ b/autoload/gen_tags/ctags.vim
@@ -90,18 +90,16 @@ function! s:ctags_gen(filename, dir) abort
   endif
 
   function! s:ctags_db_gen_done(...) abort
-    let l:dir = gen_tags#get_db_dir()
-
-    "Search for existence tags string.
-    let l:ret = stridx(&tags, l:dir)
-    if l:ret == -1
-      call s:ctags_add(l:file)
-    endif
-
     call gen_tags#statusline#clear()
   endfunction
 
   call gen_tags#system_async(l:cmd, function('s:ctags_db_gen_done'))
+
+  "Search for existence tags string.
+  let l:ret = stridx(&tags, l:dir)
+  if l:ret == -1
+    call s:ctags_add(l:file)
+  endif
 endfunction
 
 function! s:ctags_auto_load() abort

--- a/autoload/gen_tags/ctags.vim
+++ b/autoload/gen_tags/ctags.vim
@@ -70,7 +70,7 @@ function! s:ctags_gen(filename, dir) abort
   let l:dir = gen_tags#get_db_dir()
 
 
-  call gen_tags#echo('Generate project ctags database in background')
+  call gen_tags#echo('Generating ctags in background')
 
   call gen_tags#mkdir(l:dir)
 

--- a/autoload/gen_tags/gtags.vim
+++ b/autoload/gen_tags/gtags.vim
@@ -56,7 +56,7 @@ function! s:gtags_db_gen() abort
 
   call gen_tags#mkdir(l:db_dir)
 
-  call gen_tags#echo('Generate GTAGS in background')
+  call gen_tags#echo('Generating GTAGS in background')
   call gen_tags#system_async(l:cmd, function('s:gtags_db_gen_done'))
 endfunction
 

--- a/autoload/gen_tags/gtags.vim
+++ b/autoload/gen_tags/gtags.vim
@@ -50,6 +50,8 @@ function! s:gtags_db_gen() abort
     endif
     call s:gtags_add(b:file)
     unlet b:file
+
+    call gen_tags#statusline#clear()
   endfunction
 
   call gen_tags#mkdir(l:db_dir)

--- a/autoload/gen_tags/gtags.vim
+++ b/autoload/gen_tags/gtags.vim
@@ -45,13 +45,13 @@ function! s:gtags_db_gen() abort
   let l:cmd = [g:gen_tags#gtags_bin, l:db_dir, g:gen_tags#gtags_opts]
 
   function! s:gtags_db_gen_done(...) abort
+    call gen_tags#statusline#clear()
+
     if !exists('b:file')
       return
     endif
     call s:gtags_add(b:file)
     unlet b:file
-
-    call gen_tags#statusline#clear()
   endfunction
 
   call gen_tags#mkdir(l:db_dir)

--- a/autoload/gen_tags/statusline.vim
+++ b/autoload/gen_tags/statusline.vim
@@ -5,7 +5,7 @@
 " ============================================================================
 
 function! gen_tags#statusline#set(msg) abort
-  if get(g:, 'gen_tags#statusline', 0)
+  if ! get(g:, 'gen_tags#statusline', 0)
     return
   endif
 
@@ -23,7 +23,7 @@ function! gen_tags#statusline#set(msg) abort
 endfunction
 
 function! gen_tags#statusline#clear() abort
-  if get(g:, 'gen_tags#statusline', 0)
+  if ! get(g:, 'gen_tags#statusline', 0)
     return
   endif
 

--- a/autoload/gen_tags/statusline.vim
+++ b/autoload/gen_tags/statusline.vim
@@ -13,7 +13,7 @@ function! gen_tags#statusline#set(msg) abort
     let w:statusline = &statusline
   endif
 
-  if w:airline_active == 1
+  if get(w:, 'airline_active', 0)
     let w:airline_disabled = 1
   endif
 
@@ -27,7 +27,7 @@ function! gen_tags#statusline#clear() abort
     return
   endif
 
-  if w:airline_active == 1
+  if get(w:, 'airline_active', 0)
     let w:airline_disabled = 0
   endif
 

--- a/autoload/gen_tags/statusline.vim
+++ b/autoload/gen_tags/statusline.vim
@@ -5,7 +5,7 @@
 " ============================================================================
 
 function! gen_tags#statusline#set(msg) abort
-  if ! get(g:, 'gen_tags#statusline', 1)
+  if get(g:, 'gen_tags#statusline', 0)
     return
   endif
 
@@ -23,7 +23,7 @@ function! gen_tags#statusline#set(msg) abort
 endfunction
 
 function! gen_tags#statusline#clear() abort
-  if ! get(g:, 'gen_tags#statusline', 1)
+  if get(g:, 'gen_tags#statusline', 0)
     return
   endif
 

--- a/autoload/gen_tags/statusline.vim
+++ b/autoload/gen_tags/statusline.vim
@@ -1,0 +1,38 @@
+" ============================================================================
+" File: statusline.vim
+" Author: Jia Sui <jsfaint@gmail.com>
+" Description: This file contains functions for statusline
+" ============================================================================
+
+function! gen_tags#statusline#set(msg) abort
+  if ! get(g:, 'gen_tags#statusline', 1)
+    return
+  endif
+
+  if !exists('w:statusline')
+    let w:statusline = &statusline
+  endif
+
+  if w:airline_active == 1
+    let w:airline_disabled = 1
+  endif
+
+  let b:msg = a:msg
+
+  setlocal statusline=%#ModeMsg#gen_tags.vim%*%#Normal#\ %{b:msg}
+endfunction
+
+function! gen_tags#statusline#clear() abort
+  if ! get(g:, 'gen_tags#statusline', 1)
+    return
+  endif
+
+  if w:airline_active == 1
+    let w:airline_disabled = 0
+  endif
+
+  if exists('w:statusline')
+    let &statusline = w:statusline
+    unlet w:statusline
+  endif
+endfunction

--- a/doc/gen_tags.txt
+++ b/doc/gen_tags.txt
@@ -247,6 +247,15 @@ following cscope comands in your vimrc.
 <
 For more details, please refer help |cscope|
 
+------------------------------------------------------------------------------
+g:gen_tags#statusline                           *g:gen_tags#statusline*
+
+Enable/Disable statusline feature.
+If |g:gen_tags#statusline| is 1, the statusline will show tags generating info,
+else nothing happened.
+
+The default |g:gen_tags#statusline| is 1
+
 ==============================================================================
 5. Events                                       *gen_tags-events*
 

--- a/doc/gen_tags.txt
+++ b/doc/gen_tags.txt
@@ -254,7 +254,7 @@ Enable/Disable statusline feature.
 If |g:gen_tags#statusline| is 1, the statusline will show tags generating info,
 else nothing happened.
 
-The default |g:gen_tags#statusline| is 1
+The default |g:gen_tags#statusline| is 0
 
 ==============================================================================
 5. Events                                       *gen_tags-events*


### PR DESCRIPTION
When the tag is generating, some message will show in statusline, and it will disappeared when the generating is done.

It is controlled by `g:gen_tags#statusline`
`1` means enabled
`0` means disabled

The **default** value is 0