### PR TITLE
Support let g:gen_tags#find_tool options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 doc/tags
+*/__pycache__/
+*.pyc

--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -172,7 +172,7 @@ function! s:job_start(cmd, ...) abort
       let l:job.on_exit = a:1
     endif
 
-    let l:job_id = jobstart(a:cmd, l:job)
+    let l:job_id = jobstart(join(a:cmd), l:job)
   elseif has('job')
     let l:job = {
           \ 'out_cb': function('s:job_stdout'),

--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -183,7 +183,11 @@ function! s:job_start(cmd, ...) abort
     if a:0 != 0
       let l:job.exit_cb = a:1
     endif
-    let l:cmd = ['/bin/sh', '-c', join(a:cmd)]
+    if has('unix')
+      let l:cmd = ['/bin/sh', '-c', join(a:cmd)]
+    else
+      let l:cmd = ['cmd', '/c', join(a:cmd)]
+    endif
     let l:job_id = job_start(l:cmd, l:job)
   else
     if has('unix')

--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -183,8 +183,8 @@ function! s:job_start(cmd, ...) abort
     if a:0 != 0
       let l:job.exit_cb = a:1
     endif
-
-    let l:job_id = job_start(a:cmd, l:job)
+    let l:cmd = ['/bin/sh', '-c', join(a:cmd)]
+    let l:job_id = job_start(l:cmd, l:job)
   else
     if has('unix')
       let l:cmd = a:cmd + ['&']

--- a/autoload/gen_tags/ctags.vim
+++ b/autoload/gen_tags/ctags.vim
@@ -79,7 +79,12 @@ function! s:ctags_gen(filename, dir) abort
 
   if empty(a:filename)
     let l:file = l:dir . '/' . s:ctags_db
-    let l:cmd += ['-f', l:file, '-R', expand(gen_tags#find_project_root())]
+    let l:cmd += ['-f', l:file]
+    if exists('g:gen_tags#find_tool') && g:gen_tags#find_tool != ''
+      let l:cmd += ['-L-']
+    else
+      let l:cmd += ['-R', expand(gen_tags#find_project_root())]
+    endif
   else
     let l:file = a:filename
     let l:cmd += ['-f', l:file, '-R', expand(a:dir)]
@@ -278,7 +283,13 @@ function! s:ctags_update(file) abort
 endfunction
 
 function! s:ctags_cmd_pre() abort
-  let l:cmd = [g:gen_tags#ctags_bin]
+  let l:cmd = []
+
+  if exists('g:gen_tags#find_tool') && g:gen_tags#find_tool != ''
+    let l:cmd += [g:gen_tags#find_tool, expand(gen_tags#find_project_root()), '|']
+  endif
+
+  let l:cmd += [g:gen_tags#ctags_bin]
 
   "Extra flag in universal ctags, enable reference tags
   if s:is_universal_ctags()

--- a/autoload/gen_tags/gtags.vim
+++ b/autoload/gen_tags/gtags.vim
@@ -49,6 +49,12 @@ function! s:gtags_db_gen() abort
     let l:cmd += gen_tags#opt_converter(g:gen_tags#gtags_opts)
   endif
 
+  if exists('g:gen_tags#find_tool') && g:gen_tags#find_tool != ''
+    let l:find_tool_cmd = [g:gen_tags#find_tool, expand((gen_tags#find_project_root()))]
+    let l:find_tool_opt = ['-f', '-']
+    let l:cmd = l:find_tool_cmd + ['|'] + l:cmd + l:find_tool_opt
+  endif
+
   function! s:gtags_db_gen_done(...) abort
     call gen_tags#statusline#clear()
 


### PR DESCRIPTION
`g:gen_tags#find_tool` is a command that displays list filenames. When `g:gen_tags#find_tool` is set. gen_tags will use it for generating tags for list of filenames.

For example, 
```
let g:gen_tags#find_tool = 'rg --files'
```
gen_tags will execute command `rg --files | ctags -f /home/ramdhan/.cache/tags_dir/homeramdhanctftoolsgef/prj_tags -L- `.
`rg --files` command (ripgrep) can be used too for exclude filename/folder in `.gitignore`. #44 

- Support ctags only, i'am not use gtags.