### PR TITLE
check if any abs or relative are blacklisted

### DIFF
--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -260,11 +260,13 @@ function! gen_tags#isblacklist(path) abort
     endif
   endfor
 
-  for l:re in g:gen_tags#blacklist_re
-    if a:path =~ l:re
-      call gen_tags#echo('Found path ' . a:path . ' to be a blacklisted pattern')
-      return 1
-    endif
+  for l:path in [a:path, fnamemodify(a:path, ':p')]
+    for l:re in g:gen_tags#blacklist_re
+      if a:path =~ l:re
+        call gen_tags#echo('Found path ' . a:path . ' to be a blacklisted pattern')
+        return 1
+      endif
+    endfor
   endfor
 
   call gen_tags#echo('Did NOT find path ' . a:path . ' in the blacklist')

--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -260,13 +260,17 @@ function! gen_tags#isblacklist(path) abort
     endif
   endfor
 
-  for l:path in [a:path, fnamemodify(a:path, ':p')]
-    for l:re in g:gen_tags#blacklist_re
-      if a:path =~ l:re
-        call gen_tags#echo('Found path ' . a:path . ' to be a blacklisted pattern')
-        return 1
-      endif
-    endfor
+  let l:abs_path = fnamemodify(a:path, ':p')
+  for l:re in g:gen_tags#blacklist_re
+    if a:path =~ l:re
+      call gen_tags#echo('Found path ' . a:path . ' to be a blacklisted pattern')
+      return 1
+    endif
+
+    if l:abs_path =~ l:re
+      call gen_tags#echo('Found path ' . l:abs_path . ' to be a blacklisted pattern')
+      return 1
+    endif
   endfor
 
   call gen_tags#echo('Did NOT find path ' . a:path . ' in the blacklist')


### PR DESCRIPTION
I've stumbled upon particular blacklisting case: a directory which has multiple repositories. In this case both ctags and gtags return relative path while blacklist_re didn't know about rel/abs paths. I didn't come up with anything smarter than just trying both argument and abs path in loop. Please have a look, maybe there's some better way.