### PR TITLE
#bugfix jump tab page use tabp is jump to recently tab

### DIFF
--- a/autoload/gen_tags/ctags.vim
+++ b/autoload/gen_tags/ctags.vim
@@ -265,7 +265,7 @@ function! s:ctags_prune(tagfile, file) abort
 
   "Restore current tab page
   if l:pretabpage > 0
-      exec 'silent tabp' . l:pretabpage
+      exec 'silent tabp1'
   endif
 
   "Restore undofile setting


### PR DESCRIPTION
Sorry. I used the wrong `tabp` command. `tabp` is jump to recently.