### PR TITLE
Add option g:gen_tags#root_path to set working directory by user

### DIFF
--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -29,6 +29,11 @@ if !exists('g:gen_tags#root_marker')
   let g:gen_tags#root_marker = '.root'
 endif
 
+" Assign root path
+if !exists('g:gen_tags#root_path')
+  let g:gen_tags#root_path = ''
+endif
+
 "Get scm repo info
 function! gen_tags#get_scm_info() abort
   let l:scm = {'type': '', 'root': ''}
@@ -62,6 +67,11 @@ endfunction
 "if the project managed by git/hg/svn, return the repo root.
 "else return the current work directory.
 function! gen_tags#find_project_root() abort
+  " Check assign root_path
+  if !empty(glob(g:gen_tags#root_path))
+    return g:gen_tags#root_path
+  endif
+
   "If it is scm repo, use scm folder as project root
   let l:scm = gen_tags#get_scm_info()
   if !empty(l:scm['type'])

--- a/doc/gen_tags.txt
+++ b/doc/gen_tags.txt
@@ -278,7 +278,7 @@ The default |g:gen_tags#root_marker| is '.root'
 ------------------------------------------------------------------------------
 g:gen_tags#root_path                          *g:gen_tags#root_path*
 
-Assign root path to set the project root. If set |g:gen_tags#root_pat|, will
+Assign root path to set the project root. If set |g:gen_tags#root_path|, will
 ignore |g:gen_tags#root_marker|.
 
 ==============================================================================

--- a/doc/gen_tags.txt
+++ b/doc/gen_tags.txt
@@ -275,6 +275,12 @@ Custom the root_marker which used for specify the project root.
 
 The default |g:gen_tags#root_marker| is '.root'
 
+------------------------------------------------------------------------------
+g:gen_tags#root_path                          *g:gen_tags#root_path*
+
+Assign root path to set the project root. If set |g:gen_tags#root_pat|, will
+ignore |g:gen_tags#root_marker|.
+
 ==============================================================================
 5. Events                                       *gen_tags-events*
 


### PR DESCRIPTION
理由跟这个合并请求一样： https://github.com/Yggdroot/LeaderF/pull/251

让用户决定如何设置工程目录。

```viml
function! SearchRoot()
  let l:scm_list = ['.root', '.svn', '.git']
  for l:item in l:scm_list
    let l:dirs = finddir(l:item, '.;', -1)
    if !empty(l:dirs)
      return fnamemodify(l:dirs[-1].'/../', ':p:h')
    endif
  endfor
  return getcwd()
endfunction
let g:root_dir = SearchRoot()
let g:gen_tags#root_path = g:root_dir
```