### PR TITLE
Setting environment variables whenever a buffer is entered

### DIFF
--- a/autoload/gen_tags/gtags.vim
+++ b/autoload/gen_tags/gtags.vim
@@ -192,7 +192,7 @@ function! gen_tags#gtags#init() abort
 
     autocmd BufWinEnter * call s:gtags_auto_load()
 
-    autocmd BufReadPost * call s:gtags_set_env()
+    autocmd BufEnter * call s:gtags_set_env()
 
     if g:gen_tags#gtags_auto_gen
       autocmd BufReadPost * call s:gtags_auto_gen()


### PR DESCRIPTION
Currently when user opens a file other than his working project files (`init.vim` for example) environment variables will be set to values that makes `gen_tags` unusable even when user gets back to a buffer belonging to his project.
This MR addresses this issue.