### PR TITLE
Add option to specify customized cache dir

### DIFF
--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -24,6 +24,11 @@ if !exists('g:gen_tags#use_cache_dir')
   let g:gen_tags#use_cache_dir = 1
 endif
 
+" Specify cache dir
+if !exists('g:gen_tags#cache_dir')
+    let g:gen_tags#cache_dir = '$HOME/.cache/tags_dir/'
+endif
+
 " Specify default root marker
 if !exists('g:gen_tags#root_marker')
   let g:gen_tags#root_marker = '.root'
@@ -144,7 +149,10 @@ function! gen_tags#get_db_dir() abort
     let l:tagdir = l:scm['root'] . '/' . l:scm['type'] . '/tags_dir'
   else
     let l:root = gen_tags#find_project_root()
-    let l:tagdir = '$HOME/.cache/tags_dir/' . gen_tags#get_db_name(l:root)
+    " If g:gen_tags#cache_dir doesn't have '/', then insert '/' when concatenating
+    let l:tagdir = g:gen_tags#cache_dir . 
+        \ (g:gen_tags#cache_dir[-1:] == '/' ? '' : '/') .
+        \ gen_tags#get_db_name(l:root)
   endif
 
   return gen_tags#fix_path(l:tagdir)

--- a/doc/gen_tags.txt
+++ b/doc/gen_tags.txt
@@ -182,10 +182,17 @@ The default |g:gen_tags#use_cache_dir| is 1, you need to set it in  your vimrc.
     git  `<project folder>/.git/tags_dir`
     hg   `<project folder>/.hg/tags_dir`
     scn  `<project folder>/.svn/tags_dir`
-  non-git: `$HOME/.cache/tags_dir/<project name>`
+  non-git: |g:gen_tags#cache_dir|
 
 1:
-  `$HOME/.cache/tags_dir/<project name>`
+  use |g:gen_tags#cache_dir|
+
+------------------------------------------------------------------------------
+g:gen_tags#cache_dir                               *g:gen_tags#cache_dir*
+
+This option allow to specify your own cache dir.
+
+The default |g:gen_tags#cache_dir| is `'$HOME/.cache/tags_dir/'`
 
 ------------------------------------------------------------------------------
 g:gen_tags#ctags_auto_gen                       *g:gen_tags#ctags_auto_gen*


### PR DESCRIPTION
感谢菊苣的插件，很好用，已star。

我刚刚从 vim-gutentags 切换过来，发现 gen_tags.vim 不可以指定自己 cache 目录的选项。
我个人习惯上把各个插件的cache 目录同意设置为 `$HOME/.cache/nvim/...`，感觉上这个需求还是较为普遍，所以加了这个选项。