### PR TITLE
Add global accessor function for checking if any job is running

### DIFF
--- a/autoload/gen_tags/job.vim
+++ b/autoload/gen_tags/job.vim
@@ -153,3 +153,18 @@ function! s:vim_on_exit() abort
     endif
   endfor
 endfunction
+
+function! gen_tags#job#is_running() abort
+	if !exists('s:job_list')
+		return 0
+	endif
+	for l:item in s:job_list
+		let l:job_id = l:item['id']
+		let l:status = s:job_status(l:job_id)
+		if l:status ==# 'run'
+			return 1
+		endif
+	endfor
+	return 0
+endfunction
+


### PR DESCRIPTION
This is so that this function may be used to implement custom
notification messages that will call-back this funtion seeing if
we are currently generating tags. I used it to implement airline plugin.

The airline plugin may be implemented then with:

```
""" in my vimrc """""""""
function! airline#extensions#gen_tags#enable_on_section_x(...)
	if get(g:, 'airline#extensions#gen_tags#enabled', 1) && (get(g:, 'loaded_gentags#gtags', 0) || get(g:, 'loaded_gentags#ctags', 0))
		call airline#parts#define_function('gen_tags', 'airline#extensions#gen_tags#status')
		let g:airline_section_x = airline#section#create_right(['gen_tags'])
	endif
endfunction
let g:airline#extensions#gen_tags#enabled = 1
call airline#add_statusline_func('airline#extensions#gen_tags#enable_on_section_x')

""""""""""""" in autoload """"""""""

if !get(g:, 'loaded_gentags#gtags', 0) && !get(g:, 'loaded_gentags#ctags', 0)
	finish
endif

function! airline#extensions#gen_tags#status()
  return gen_tags#job#is_running() != 0 ? 'Gen. gen_tags' : ''
  "      ^^^^^^^^^^^^^^^^^^^^^^^^^ this is needed
endfunction

function! airline#extensions#gen_tags#init(ext)
  call airline#parts#define_function('gen_tags', 'airline#extensions#gen_tags#status')
endfunction
```

which I guess will pull request to airline later.