### PR TITLE
fix `get_scm_info` implementation

### DIFF
--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -48,22 +48,12 @@ function! gen_tags#get_scm_info() abort
 
   "Detect scm type
   for l:item in l:scm_list
-    let l:dir = finddir(l:item, '.;')
+    let l:dir = finddir(l:item, '.;'.l:scm['root'])
     if !empty(l:dir)
       let l:scm['type'] = l:item
-      let l:scm['root'] = l:dir
-      break
+      let l:scm['root'] = gen_tags#fix_path(fnamemodify(fnamemodify(l:dir, ':h'), ':p:h'))
     endif
   endfor
-
-  "Not a scm repo, return
-  if empty(l:scm['type'])
-    return l:scm
-  endif
-
-  "Get scm root
-  let l:scm['root'] = gen_tags#fix_path(fnamemodify(l:scm['root'], ':p:h'))
-  let l:scm['root'] = substitute(l:scm['root'], '/' . l:scm['type'], '', 'g')
 
   return l:scm
 endfunction

--- a/autoload/gen_tags.vim
+++ b/autoload/gen_tags.vim
@@ -44,13 +44,19 @@ function! gen_tags#get_scm_info() abort
   let l:scm = {'type': '', 'root': ''}
 
   "Supported scm repo
-  let l:scm_list = [g:gen_tags#root_marker, '.git', '.hg', '.svn']
+  let l:scm_list = [
+        \ [g:gen_tags#root_marker, 'dir'],
+        \ ['.git', 'file'],
+        \ ['.git', 'dir'],
+        \ ['.hg', 'dir'],
+        \ ['.svn', 'dir'],
+        \ ]
 
   "Detect scm type
   for l:item in l:scm_list
-    let l:dir = finddir(l:item, '.;'.l:scm['root'])
+    let l:dir = function('find'.l:item[1])(l:item[0], '.;'.l:scm['root'])
     if !empty(l:dir)
-      let l:scm['type'] = l:item
+      let l:scm['type'] = l:item[0]
       let l:scm['root'] = gen_tags#fix_path(fnamemodify(fnamemodify(l:dir, ':h'), ':p:h'))
     endif
   endfor


### PR DESCRIPTION
Fix 2 issues with `get_scm_info`:

1. correctly handle nested repositories (e.g. a Mercurial repository somewhere under a Git versioned home directory)
2. correctly handle Git sub-modules